### PR TITLE
Update to tapir 1.4.0 [wip]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set up JDK 19
+    - name: Set up JDK 20
       uses: oracle-actions/setup-java@v1
       with:
         website: jdk.java.net
-        release: 19
+        release: 20
     - name: Cache sbt
       uses: actions/cache@v2
       with:
@@ -48,11 +48,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 19
+      - name: Set up JDK 20
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
-          release: 19
+          release: 20
       - name: Compile
         run: sbt compile
       - name: Publish artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val netty = (projectMatrix in file("netty"))
   )
   .jvmPlatform(scalaVersions = scalaAll)
 
-lazy val helidonVersion = "4.0.0-ALPHA5"
+lazy val helidonVersion = "4.0.0-ALPHA6"
 lazy val nima = (projectMatrix in file("nima"))
   .settings(commonSettings: _*)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   fork := true
 )
 
-val tapirVersion = "1.2.4"
+val tapirVersion = "1.2.13"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16" % Test
 
 lazy val rootProject = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,7 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   fork := true
 )
 
-//val tapirVersion = "1.4.0"
-val tapirVersion = "1.3.0"
+val tapirVersion = "1.4.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16" % Test
 
 lazy val rootProject = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   fork := true
 )
 
-val tapirVersion = "1.2.13"
+//val tapirVersion = "1.4.0"
+val tapirVersion = "1.3.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16" % Test
 
 lazy val rootProject = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val netty = (projectMatrix in file("netty"))
   )
   .jvmPlatform(scalaVersions = scalaAll)
 
+lazy val helidonVersion = "4.0.0-ALPHA5"
 lazy val nima = (projectMatrix in file("nima"))
   .settings(commonSettings: _*)
   .settings(
@@ -42,8 +43,14 @@ lazy val nima = (projectMatrix in file("nima"))
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.tapir" %% "tapir-server" % tapirVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-server-tests" % tapirVersion % Test,
-      "io.helidon.nima.webserver" % "helidon-nima-webserver" % "4.0.0-ALPHA2",
+      "io.helidon.nima.webserver" % "helidon-nima-webserver" % helidonVersion,
       scalaTest
-    )
+    ) ++ loggerDependencies
   )
   .jvmPlatform(scalaVersions = scalaAll)
+
+lazy val loggerDependencies = Seq(
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "ch.qos.logback" % "logback-classic" % "1.4.7",
+  "io.helidon.logging" % "helidon-logging-slf4j" % helidonVersion, // to see logs from helidon
+)

--- a/netty/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServer.scala
+++ b/netty/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServer.scala
@@ -9,7 +9,6 @@ import sttp.tapir.server.netty.internal.{NettyBootstrap, NettyServerHandler}
 import java.net.{InetSocketAddress, SocketAddress}
 import java.nio.file.Path
 import java.util.concurrent.Executors
-import scala.concurrent.Future
 
 case class NettyIdServer[SA <: SocketAddress](routes: Vector[IdRoute], options: NettyIdServerOptions[SA]) {
   private val executor = Executors.newVirtualThreadPerTaskExecutor()
@@ -53,7 +52,7 @@ case class NettyIdServer[SA <: SocketAddress](routes: Vector[IdRoute], options: 
           executor.submit(new Runnable {
             override def run(): Unit = f()
           })
-          Future.successful(())
+          ()
         }
       ),
       eventLoopGroup

--- a/netty/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServerInterpreter.scala
+++ b/netty/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServerInterpreter.scala
@@ -15,7 +15,10 @@ trait NettyIdServerInterpreter {
       nettyServerOptions.createFile,
       nettyServerOptions.deleteFile,
       new RunAsync[Id] {
-        override def apply[T](f: => Id[T]): Unit = f
+        override def apply[T](f: => Id[T]): Unit = {
+          f
+          ()
+        }
       }
     )
   }

--- a/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
@@ -38,6 +38,7 @@ trait NimaServerInterpreter {
           log.debug(s"toHandler: RequestResult.Response: $tapirResponse")
           helidonResponse.status(Http.Status.create(tapirResponse.code.code))
           tapirResponse.headers.groupBy(_.name).foreach { case (name, headers) =>
+            log.debug(s"toHandler: RequestResult.Response: header: $name [${headers.map(_.value)}]")
             helidonResponse.header(name, headers.map(_.value): _*)
           }
           log.debug("toHandler: streaming body")
@@ -47,8 +48,9 @@ trait NimaServerInterpreter {
             log.debug("toHandler: streaming body: empty")
             helidonResponse.send()
           } { tapirInputStream =>
-            log.debug("toHandler: streaming body: stream")
+            log.debug("toHandler: streaming body: stream creation")
             val helidonOutputStream = helidonResponse.outputStream()
+            log.debug("toHandler: streaming body: stream transfer")
             tapirInputStream.transferTo(helidonOutputStream)
             log.debug("toHandler: streaming close")
             helidonOutputStream.close()

--- a/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
@@ -41,18 +41,21 @@ trait NimaServerInterpreter {
             helidonResponse.header(name, headers.map(_.value): _*)
           }
           log.debug("toHandler: streaming body")
+          log.debug(s"toHandler: tapirResponse: $tapirResponse")
 
           tapirResponse.body.fold {
-            log.debug("toHandler: streaming body - EMPTY")
+            log.debug("toHandler: streaming body: empty")
             helidonResponse.send()
           } { tapirInputStream =>
+            log.debug("toHandler: streaming body: stream")
             val helidonOutputStream = helidonResponse.outputStream()
             tapirInputStream.transferTo(helidonOutputStream)
             log.debug("toHandler: streaming close")
             helidonOutputStream.close()
           }
 
-        case RequestResult.Failure(_) =>
+        case r@RequestResult.Failure(_) =>
+          log.debug(s"toHandler: RequestResult.Failure: ", r)
           helidonResponse.next()
           ()
       }

--- a/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
@@ -53,7 +53,8 @@ trait NimaServerInterpreter {
           }
 
         case RequestResult.Failure(_) =>
-          val ignore = helidonResponse.next()
+          helidonResponse.next()
+          ()
       }
     }
   }

--- a/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/NimaServerInterpreter.scala
@@ -1,17 +1,19 @@
 package sttp.tapir.server.nima
 
+import com.typesafe.scalalogging.Logger
 import io.helidon.common.http.Http
-import io.helidon.nima.webserver.http.{Handler, ServerRequest, ServerResponse}
+import io.helidon.nima.webserver.http.{Handler, ServerRequest => HelidonServerRequest, ServerResponse => HelidonServerResponse}
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.RequestResult
 import sttp.tapir.server.interceptor.reject.RejectInterceptor
 import sttp.tapir.server.interpreter.{BodyListener, FilterServerEndpoints, ServerInterpreter}
-import sttp.tapir.server.nima.internal.{idMonad, NimaBodyListener, NimaRequestBody, NimaServerRequest, NimaToResponseBody}
+import sttp.tapir.server.nima.internal.{NimaBodyListener, NimaRequestBody, NimaServerRequest, NimaToResponseBody, idMonad}
 
 import java.io.InputStream
 
 trait NimaServerInterpreter {
+  val log = Logger(getClass.getName)
   def nimaServerOptions: NimaServerOptions
 
   def toHandler(ses: List[ServerEndpoint[Any, Id]]): Handler = {
@@ -20,8 +22,8 @@ trait NimaServerInterpreter {
     val responseBody = new NimaToResponseBody
     val interceptors = RejectInterceptor.disableWhenSingleEndpoint(nimaServerOptions.interceptors, ses)
 
-    (req: ServerRequest, res: ServerResponse) => {
-      implicit val bodyListener: BodyListener[Id, InputStream] = new NimaBodyListener(res)
+    (helidonRequest: HelidonServerRequest, helidonResponse: HelidonServerResponse) => {
+      implicit val bodyListener: BodyListener[Id, InputStream] = new NimaBodyListener(helidonResponse)
 
       val serverInterpreter = new ServerInterpreter[Any, Id, InputStream, NoStreams](
         filteredEndpoints,
@@ -31,20 +33,27 @@ trait NimaServerInterpreter {
         nimaServerOptions.deleteFile
       )
 
-      serverInterpreter(NimaServerRequest(req)) match {
-        case RequestResult.Response(response) =>
-          res.status(Http.Status.create(response.code.code))
-          response.headers.groupBy(_.name).foreach { case (name, headers) =>
-            res.header(name, headers.map(_.value): _*)
+      serverInterpreter(NimaServerRequest(helidonRequest)) match {
+        case RequestResult.Response(tapirResponse) =>
+          log.debug(s"toHandler: RequestResult.Response: $tapirResponse")
+          helidonResponse.status(Http.Status.create(tapirResponse.code.code))
+          tapirResponse.headers.groupBy(_.name).foreach { case (name, headers) =>
+            helidonResponse.header(name, headers.map(_.value): _*)
           }
-          response.body.foreach { is =>
-            val os = res.outputStream()
-            is.transferTo(os)
-            os.close()
+          log.debug("toHandler: streaming body")
+
+          tapirResponse.body.fold {
+            log.debug("toHandler: streaming body - EMPTY")
+            helidonResponse.send()
+          } { tapirInputStream =>
+            val helidonOutputStream = helidonResponse.outputStream()
+            tapirInputStream.transferTo(helidonOutputStream)
+            log.debug("toHandler: streaming close")
+            helidonOutputStream.close()
           }
 
         case RequestResult.Failure(_) =>
-          val ignore = res.next()
+          val ignore = helidonResponse.next()
       }
     }
   }

--- a/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaBodyListener.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaBodyListener.scala
@@ -9,6 +9,7 @@ import scala.util.{Success, Try}
 
 private[nima] class NimaBodyListener(res: JavaNimaServerResponse) extends BodyListener[Id, InputStream] {
   override def onComplete(body: InputStream)(cb: Try[Unit] => Unit): InputStream = {
+//    println("nima: onComplete")
     res.whenSent(() => cb(Success(())))
     body
   }

--- a/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaRequestBody.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaRequestBody.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.nima.internal
 
 import io.helidon.nima.webserver.http.{ServerRequest => JavaNimaServerRequest}
 import sttp.capabilities
-import sttp.tapir.{FileRange, RawBodyType, TapirFile}
+import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, TapirFile}
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
@@ -23,6 +23,7 @@ private[nima] class NimaRequestBody(createFile: ServerRequest => TapirFile) exte
       case RawBodyType.ByteArrayBody       => RawValue(asByteArray)
       case RawBodyType.ByteBufferBody      => RawValue(ByteBuffer.wrap(asByteArray))
       case RawBodyType.InputStreamBody     => RawValue(asInputStream)
+      case RawBodyType.InputStreamRangeBody => RawValue(InputStreamRange(() => asInputStream))
       case RawBodyType.FileBody =>
         val file = createFile(serverRequest)
         Files.copy(asInputStream, file.toPath, StandardCopyOption.REPLACE_EXISTING)

--- a/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaServerRequest.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaServerRequest.scala
@@ -30,6 +30,7 @@ private[nima] case class NimaServerRequest(r: JavaNimaServerRequest, attributes:
     Uri.unsafeParse(s"$protocol://$authority$path$query$fragment")
   }
 
+  println(s"NimaServerRequest: headers: ${r.headers()}")
   override def headers: Seq[Header] = r.headers().asScala.toSeq.flatMap(hv => hv.allValues().asScala.map(v => Header(hv.name(), v)))
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): NimaServerRequest = copy(attributes = attributes.put(k, v))

--- a/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaServerRequest.scala
+++ b/nima/src/main/scala/sttp/tapir/server/nima/internal/NimaServerRequest.scala
@@ -10,11 +10,13 @@ import java.net.{InetSocketAddress, SocketAddress}
 import scala.jdk.CollectionConverters.IterableHasAsScala
 
 private[nima] case class NimaServerRequest(r: JavaNimaServerRequest, attributes: AttributeMap = AttributeMap.Empty) extends ServerRequest {
+//  println(s"NimaServerRequest: PATH: ${r.path()}")
   override def protocol: String = r.prologue().protocol()
   override def connectionInfo: ConnectionInfo =
     ConnectionInfo(toInetSocketAddress(r.localPeer().address()), toInetSocketAddress(r.remotePeer().address()), Some(r.isSecure))
   override def underlying: Any = r
   override def pathSegments: List[String] = uri.pathSegments.segments.map(_.v).filter(_.nonEmpty).toList
+//  println(s"NimaServerRequest: PATH: Segments ${pathSegments}")
   override def queryParameters: QueryParams = uri.params
   override def method: Method = Method.unsafeApply(r.prologue().method().text())
 

--- a/nima/src/test/resources/logback.xml
+++ b/nima/src/test/resources/logback.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="io.helidon" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    <logger name="sttp.tapir.server.nima" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/nima/src/test/resources/logback.xml
+++ b/nima/src/test/resources/logback.xml
@@ -8,10 +8,12 @@
         </layout>
     </appender>
 
-    <logger name="io.helidon" level="info" additivity="false">
+<!--    <logger name="io.helidon" level="info" additivity="false">-->
+    <logger name="io.helidon" level="debug" additivity="false">
         <appender-ref ref="CONSOLE"/>
     </logger>
-    <logger name="sttp.tapir.server.nima" level="info" additivity="false">
+<!--    <logger name="sttp.tapir.server.nima" level="info" additivity="false">-->
+    <logger name="sttp.tapir.server.nima" level="debug" additivity="false">
         <appender-ref ref="CONSOLE"/>
     </logger>
 

--- a/nima/src/test/resources/logback.xml
+++ b/nima/src/test/resources/logback.xml
@@ -8,10 +8,10 @@
         </layout>
     </appender>
 
-    <logger name="io.helidon" level="INFO" additivity="false">
+    <logger name="io.helidon" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
     </logger>
-    <logger name="sttp.tapir.server.nima" level="INFO" additivity="false">
+    <logger name="sttp.tapir.server.nima" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
     </logger>
 

--- a/nima/src/test/scala/sttp/tapir/server/nima/NimaServerTest.scala
+++ b/nima/src/test/scala/sttp/tapir/server/nima/NimaServerTest.scala
@@ -4,6 +4,7 @@ import cats.effect.{IO, Resource}
 import org.scalatest.EitherValues
 import sttp.tapir.server.nima.internal.idMonad
 import sttp.tapir.server.tests._
+//import sttp.tapir.server.testsLocal.ServerBasicTestsLocal
 import sttp.tapir.tests.{Test, TestSuite}
 
 class NimaServerTest extends TestSuite with EitherValues {
@@ -13,6 +14,8 @@ class NimaServerTest extends TestSuite with EitherValues {
         .eval(IO.delay {
           val interpreter = new NimaTestServerInterpreter()
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
+
+//          new ServerBasicTestsLocal(createServerTest, interpreter, invulnerableToUnsanitizedHeaders = false).tests()
 
           new ServerBasicTests(createServerTest, interpreter, invulnerableToUnsanitizedHeaders = false).tests() ++
             new AllServerTests(createServerTest, interpreter, backend, basic = false, multipart = false).tests()

--- a/nima/src/test/scala/sttp/tapir/server/nima/NimaTestServerInterpreter.scala
+++ b/nima/src/test/scala/sttp/tapir/server/nima/NimaTestServerInterpreter.scala
@@ -14,12 +14,14 @@ class NimaTestServerInterpreter() extends TestServerInterpreter[Id, Any, NimaSer
     NimaServerInterpreter(serverOptions).toHandler(es)
   }
 
-  override def server(routes: NonEmptyList[Handler]): Resource[IO, Port] = {
+  override def server(nimaRoutes: NonEmptyList[Handler]): Resource[IO, Port] = {
     val bind = IO.blocking {
       WebServer
         .builder()
-        .routing { (b: HttpRouting.Builder) =>
-          routes.iterator.foreach(b.any)
+        .routing { (builder: HttpRouting.Builder) =>
+          nimaRoutes
+            .iterator
+            .foreach(nimaHandler => builder.any(nimaHandler))
         }
         .start()
     }

--- a/nima/src/test/scala/sttp/tapir/server/nima/NimaTestServerInterpreter.scala
+++ b/nima/src/test/scala/sttp/tapir/server/nima/NimaTestServerInterpreter.scala
@@ -25,7 +25,9 @@ class NimaTestServerInterpreter() extends TestServerInterpreter[Id, Any, NimaSer
     }
 
     Resource
-      .make(bind)(binding => IO.blocking(binding.stop()))
+      .make(bind) { binding =>
+        IO.blocking(binding.stop()).map(_ => ())
+      }
       .map(b => b.port)
   }
 }

--- a/nima/src/test/scala/sttp/tapir/server/nima/SleepDemo.scala
+++ b/nima/src/test/scala/sttp/tapir/server/nima/SleepDemo.scala
@@ -9,6 +9,13 @@ object SleepDemo extends App {
     "hello, world!"
   }
   val h = NimaServerInterpreter().toHandler(List(e))
-  WebServer.builder().routing(_.any(h)).port(8080).start()
+  WebServer
+    .builder()
+    .routing { builder =>
+      builder.any(h)
+      ()
+    }
+    .port(8080)
+    .start()
   println("Started")
 }


### PR DESCRIPTION
There is still an issue with tapir test case 

```sbt '~nima/testOnly sttp.tapir.server.nima.NimaServerTest -- -z "should return pre-gzipped files"'```

that checks for accepted encodings:

```for (acceptEncodingValue <- List("gzip, deflate", "gzip", "deflate, gzip;q=1.0, *;q=0.5"))```

it is about the last value "deflate, gzip;q=1.0, *;q=0.5"
As I can see in helidon src `ContentEncodingSupportTest`,  there is no case with acceptEncoding containing wildcard (also in the main line) - perhaps the issue is somewhere around it?